### PR TITLE
Fixes #18 by mapping SWPX 'justify' to OOML 'both'

### DIFF
--- a/src/main/java/org/wordinator/xml2docx/generator/DocxGenerator.java
+++ b/src/main/java/org/wordinator/xml2docx/generator/DocxGenerator.java
@@ -2047,7 +2047,8 @@ public class DocxGenerator {
 						makeParagraph(p, cursor);
 						if (null != align) {
 						  if ("JUSTIFY".equalsIgnoreCase(align)) {
-						    align = "DISTRIBUTE"; // Slight mistmatch between markup and model
+						    // Issue 18: "BOTH" is the better match to "JUSTIFY"
+						    align = "BOTH"; // Slight mistmatch between markup and model
 						  }
               if ("CHAR".equalsIgnoreCase(align)) {
                 // I'm not sure this is the best mapping but it seemed close enough

--- a/src/main/xsl/html2docx/baseProcessing.xsl
+++ b/src/main/xsl/html2docx/baseProcessing.xsl
@@ -443,17 +443,17 @@
     
     <xsl:variable name="class-values" as="xs:string*" select="tokenize(@class, ' ')"/>
     <xsl:choose>
-      <xsl:when test="($class-values ! contains(., 'center')) = true()">
+      <xsl:when test="$class-values = ('center')">
         <xsl:attribute name="align" select="'center'"/>
       </xsl:when>
-      <xsl:when test="($class-values ! contains(., 'left')) = true()">
+      <xsl:when test="$class-values = ('left')">
         <xsl:attribute name="align" select="'left'"/>
       </xsl:when>
-      <xsl:when test="($class-values ! contains(., 'right')) = true()">
+      <xsl:when test="$class-values = ('right')">
         <xsl:attribute name="align" select="'right'"/>
       </xsl:when>
-      <xsl:when test="($class-values ! contains(., 'justify')) = true()">
-        <xsl:attribute name="align" select="'justify'"/>
+      <xsl:when test="$class-values = ('both', 'justify')">
+        <xsl:attribute name="align" select="'both'"/>
       </xsl:when>
     </xsl:choose>
   </xsl:template>

--- a/src/test/java/org/wordinator/xml2docx/TestDocxGenerator.java
+++ b/src/test/java/org/wordinator/xml2docx/TestDocxGenerator.java
@@ -169,4 +169,5 @@ public class TestDocxGenerator extends TestCase {
 		}
 		
 	}
+
 }


### PR DESCRIPTION
Treat HTML @class values 'both' and 'justify' as 'justify' in SWPX.

Map SWPX "justify" to OOML "both" in DOCX.