### PR TITLE
Issue #47: Implement support for constructing complex fields

### DIFF
--- a/src/main/doctypes/simplewpml/simplewpml.rng
+++ b/src/main/doctypes/simplewpml/simplewpml.rng
@@ -440,6 +440,7 @@
           <ref name="page-number-ref"/>
           <ref name="run"/>
           <ref name="object"/>
+          <ref name="complexField"/>
         </choice>
       </zeroOrMore>
       <ref name="style-atts"/>
@@ -1591,9 +1592,43 @@
         </attribute>
       </optional>
     </element>    
-  </define>                      
+  </define>                   
   
+  <define name="complexField" ns="urn:ns:wordinator:simplewpml">
+    <element name="complexField">
+      <a:documentation>
+        <h2>Represents a field code</h2>
+        <p>The details of the field codes are defined by the Office Open XML specification.</p>
+      </a:documentation>           
+      <ref name="instructionText"/>
+      <optional>
+        <ref name="fieldResults"/>
+      </optional>
+    </element>
+  </define>
   
+  <define name="instructionText" ns="urn:ns:wordinator:simplewpml">
+    <element name="instructionText" >
+      <a:documentation>
+        <h2>Field Instructions</h2>
+        <p>The instruction text for the field (i.e., "REF _Ref338144563 \n \h").</p>
+      </a:documentation>           
+      <text/>
+    </element>
+  </define>
+  
+  <define name="fieldResults" ns="urn:ns:wordinator:simplewpml">
+    <element name="fieldResults" >
+      <a:documentation>
+        <h2>Field Results</h2>
+        <p>The literal results of the field (the content that follows the w:fieldCharType "separate" marker in the OOXML content).</p>
+      </a:documentation>           
+      <zeroOrMore>
+        <ref name="run"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
   <define name="measurement">
     <data type="string">
       <param name="pattern">(\+|\-)?[0-9]+(\.[0-9]+)?(pt|pc|mm|cm|in|em|px)</param>

--- a/src/main/java/org/wordinator/xml2docx/generator/DocxConstants.java
+++ b/src/main/java/org/wordinator/xml2docx/generator/DocxConstants.java
@@ -118,8 +118,10 @@ public final class DocxConstants {
 	// Elements:
 	public static final QName QNAME_COLS_ELEM = new QName(SIMPLE_WP_NS, "cols");
 	public static final QName QNAME_COL_ELEM = new QName(SIMPLE_WP_NS, "col");
+  public static final QName QNAME_FIELDRESULTS_ELEM = new QName(SIMPLE_WP_NS, "fieldResults");
   public static final QName QNAME_FOOTNOTEREF_ELEM = new QName(OO_WPML_NS, "footnoteRef");
   public static final QName QNAME_FOOTNOTEREFEREMCE_ELEM = new QName(OO_WPML_NS, "footnoteReference");
+  public static final QName QNAME_INSTRUCTIONTEXT_ELEM = new QName(SIMPLE_WP_NS, "instructionText");
   public static final QName QNAME_P_ELEM = new QName(SIMPLE_WP_NS, "p");
   public static final QName QNAME_W_P_ELEM = new QName(OO_WPML_NS, "p");
   public static final QName QNAME_R_ELEM = new QName(OO_WPML_NS, "r");

--- a/src/test/resources/simplewp/simplewpml-issue-47.swpx
+++ b/src/test/resources/simplewp/simplewpml-issue-47.swpx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/css" href="../../../main/doctypes/simplewpml/css/simplewpml.css"?>
+<?xml-model href="../../../main/doctypes/simplewpml/simplewpml.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<document xmlns="urn:ns:wordinator:simplewpml">
+  <page-sequence-properties>
+    <page-number-properties
+      format="custom"
+      xslt-format="1."
+      start="1"
+    />
+    <headers-and-footers>
+      <header>
+        <p><run>Odd Header Paragraph 1</run></p>
+        <p>
+          <run>Page </run>
+          <complexField>
+            <instructionText>PAGE</instructionText>
+            <fieldResults>
+              <run>0</run>
+            </fieldResults>
+          </complexField>
+          <run> of </run>
+          <complexField>
+            <instructionText> NUMPAGES </instructionText>
+            <fieldResults>
+              <run>0</run>
+            </fieldResults>
+          </complexField>          
+        </p>
+      </header>
+      <header type="even">
+        <p><run>Even Header Paragraph 1</run></p>
+      </header>
+      <footer>
+        <p>
+          <run>Odd Footer: </run>
+          <page-number-ref format="numberInDash"/>
+          <run> After page-number-ref</run>
+        </p>
+      </footer>
+      <footer type="even">
+        <p><run>Even Footer</run></p>
+      </footer>
+    </headers-and-footers>
+  </page-sequence-properties>
+  <body>
+    <p style="Heading1">
+      <run style="Strong">Issue 47: Complex Fields</run>
+      <bookmarkStart id="bm1" name="bm1"/>
+    </p>
+    <p>
+      <run>Complex field (between slashes) /</run>
+      <complexField>
+        <instructionText>DATE \@ "dddd, MMMM dd, yyyy HH:mm:ss"</instructionText>
+        <fieldResults><run>Date Results</run></fieldResults>
+      </complexField>
+      <run>/ After the complex field.</run>
+      <run>
+        <break type="page"/>
+      </run>
+    </p>
+  </body>
+</document>


### PR DESCRIPTION
Implemented support for new SWPX element complexField that lets you create any complex field.

New markup is:

```
      <complexField>
        <instructionText>DATE \@ "dddd, MMMM dd, yyyy HH:mm:ss"</instructionText>
        <fieldResults><run>Date Results</run></fieldResults>
      </complexField>

```

The fieldResults are optional and should be replaced by whatever Word generates.