### PR TITLE
Don't swallow the traceback in case of errors

### DIFF
--- a/src/main/java/org/wordinator/xml2docx/MakeDocx.java
+++ b/src/main/java/org/wordinator/xml2docx/MakeDocx.java
@@ -71,7 +71,7 @@ public class MakeDocx
 			
 	public static final String XSLT_PARAM_CHUNKLEVEL = "chunklevel";
 
-	public static void main( String[] args ) throws ParseException
+	public static void main( String[] args ) throws Exception
     {
 	    boolean GOOD_OPTIONS = false;
 	    Options options = null;
@@ -86,10 +86,7 @@ public class MakeDocx
     	  handleCommandLine(options, args, log);
     	} catch (ParseException e) {
     	  GOOD_OPTIONS = false;
-    	} catch (Exception e) {
-    	  log.error(e.getClass().getSimpleName() + ": " + e.getMessage());
-    	  System.exit(1);
-      }
+    	}
 
     	if (!GOOD_OPTIONS) {
         HelpFormatter formatter = new HelpFormatter();


### PR DESCRIPTION
I ran Wordinator just to try it out, and got this output:

```
MacBook-Pro:mathml larsga$ java -jar ~/cvs-co/wordinator/target/wordinator-1.1.2-jar-with-dependencies.jar -i input.xml -o output.docx -t example.dotx
+ 2023-01-27 11:44:20,763 [INFO ] Input document or directory='input.xml'
+ 2023-01-27 11:44:20,766 [INFO ] Output directory           ='output.docx'
+ 2023-01-27 11:44:20,766 [INFO ] DOTX template              ='example.dotx'
+ 2023-01-27 11:44:20,766 [INFO ] XSLT template              =Not specified
+ 2023-01-27 11:44:20,766 [INFO ] Catalog                    =Not specified
+ 2023-01-27 11:44:20,766 [INFO ] Chunk level                ='root'
+ 2023-01-27 11:44:21,353 [ERROR] NullPointerException: null
```

The last line here is a problem: I clearly hit a bug in Wordinator, but Wordinator is catching the exception and destroying the necessary debug information (the traceback). This should not happen.

This PR fixes the problem so that the user can now see (and fix or properly report) the bug:

```
MacBook-Pro:mathml larsga$ java -jar ~/cvs-co/wordinator/target/wordinator-1.1.2-jar-with-dependencies.jar -i input.xml -o output.docx -t example.dotx
+ 2023-01-27 11:46:25,246 [INFO ] Input document or directory='input.xml'
+ 2023-01-27 11:46:25,248 [INFO ] Output directory           ='output.docx'
+ 2023-01-27 11:46:25,248 [INFO ] DOTX template              ='example.dotx'
+ 2023-01-27 11:46:25,248 [INFO ] XSLT template              =Not specified
+ 2023-01-27 11:46:25,248 [INFO ] Catalog                    =Not specified
+ 2023-01-27 11:46:25,248 [INFO ] Chunk level                ='root'
Exception in thread "main" java.lang.NullPointerException
	at org.wordinator.xml2docx.MakeDocx.handleCommandLine(MakeDocx.java:165)
	at org.wordinator.xml2docx.MakeDocx.main(MakeDocx.java:86)
```

I verified that the JVM sets the exit code to 1 by itself when an exception terminates the JVM, so the behaviour at the shell level remains the same.