### PR TITLE
Fix NPE if -o is just a file name

### DIFF
--- a/src/main/java/org/wordinator/xml2docx/MakeDocx.java
+++ b/src/main/java/org/wordinator/xml2docx/MakeDocx.java
@@ -162,7 +162,13 @@ public class MakeDocx
     	
     	File outDir = outFile; // Normal case: specify output directory
     	if (outFile.getName().endsWith(".docx")) {
-    		outDir = outFile.getParentFile();
+          // if outFile is just a filename .getParentFile() will return null
+          // need to resolve it to an absolute path to work around it
+          if (!outFile.isAbsolute()) {
+            outFile = new File(outFile.getAbsolutePath());
+          }
+          
+          outDir = outFile.getParentFile();
     	}
     	
     	if (!outDir.exists()) {


### PR DESCRIPTION
Running

```
java -jar ~/cvs-co/wordinator/target/wordinator-1.1.2-jar-with-dependencies.jar -i input.xml -o output.docx -t example.dotx
```

causes Wordinator to crash, because it tries to get the parent directory of `output.docx`, but since this is just a file name Java doesn't find any parent and returns `null`, triggering an NPE on the next line.

This PR fixes the problem.