### PR TITLE
Upgrade to latest Apache POI and XmlBeans

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,17 +57,17 @@ arbitrary XML, JSON, etc.</description>
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
-      <version>4.1.2</version>
+      <version>5.2.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi-ooxml</artifactId>
-      <version>4.1.2</version>
+      <version>5.2.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlbeans</groupId>
       <artifactId>xmlbeans</artifactId>
-      <version>3.1.0</version>
+      <version>5.1.1</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/org/wordinator/xml2docx/generator/DocxGenerator.java
+++ b/src/main/java/org/wordinator/xml2docx/generator/DocxGenerator.java
@@ -59,6 +59,8 @@ import org.apache.xmlbeans.XmlCursor.TokenType;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.impl.xb.xmlschema.SpaceAttribute.Space;
+import org.openxmlformats.schemas.officeDocument.x2006.sharedTypes.STOnOff1;
+import org.openxmlformats.schemas.officeDocument.x2006.sharedTypes.STVerticalAlignRun;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTBody;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTBookmark;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTBorder;
@@ -95,13 +97,11 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.STFldCharType;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHdrFtr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STMerge;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STNumberFormat;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.STOnOff;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STPageOrientation;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STSectionMark;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STShd;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STStyleType;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STTblLayoutType;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.STVerticalAlignRun;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.impl.STOnOffImpl;
 import org.wordinator.xml2docx.xwpf.model.XWPFHeaderFooterPolicy;
 
@@ -610,7 +610,7 @@ public class DocxGenerator {
     //           when the Word Update automatic links on open setting is active.
     CTFldChar field = para.createRun().getCTR().addNewFldChar();
     field.setFldCharType(STFldCharType.BEGIN);
-    field.setDirty(STOnOff.TRUE);
+    field.setDirty(STOnOff1.ON);
     CTText ctText = para.createRun().getCTR().addNewInstrText();
     ctText.setSpace(Space.PRESERVE);
     String tocOptions = "";
@@ -999,7 +999,7 @@ public class DocxGenerator {
               localSectPr = doc.getDocument().getBody().getSectPr();              
             }
             CTOnOff titlePg = (localSectPr.isSetTitlePg() ? localSectPr.getTitlePg() : localSectPr.addNewTitlePg());
-            titlePg.setVal(STOnOff.TRUE);
+            titlePg.setVal(STOnOff1.ON);
           }
           if (type == HeaderFooterType.DEFAULT) {
             haveOddHeader = true;
@@ -1034,7 +1034,7 @@ public class DocxGenerator {
               localSectPr = doc.getDocument().getBody().getSectPr();              
             }
             CTOnOff titlePg = (localSectPr.isSetTitlePg() ? localSectPr.getTitlePg() : localSectPr.addNewTitlePg());
-            titlePg.setVal(STOnOff.TRUE);
+            titlePg.setVal(STOnOff1.ON);
           }
           if (isDocument) {
             // Document-level footer
@@ -1475,8 +1475,8 @@ public class DocxGenerator {
               run.setItalic(value);
           } else if ("outline".equals(attName)) {
               CTOnOff onOff = CTOnOff.Factory.newInstance();
-              onOff.setVal(STOnOff.Enum.forString(attValue));
-              run.getCTR().getRPr().setOutline(onOff);
+              onOff.setVal(STOnOff1.Enum.forString(attValue));
+              run.getCTR().getRPr().setOutlineArray(new CTOnOff[] { onOff });
           } else if ("position".equals(attName)) {
             int val = Integer.parseInt(attValue);
               run.setTextPosition(val);

--- a/src/main/java/org/wordinator/xml2docx/xwpf/model/XWPFHeaderFooterPolicy.java
+++ b/src/main/java/org/wordinator/xml2docx/xwpf/model/XWPFHeaderFooterPolicy.java
@@ -26,6 +26,7 @@ import org.apache.poi.xwpf.usermodel.XWPFHeaderFooter;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFRelation;
 import org.apache.xmlbeans.impl.values.XmlValueOutOfRangeException;
+import org.openxmlformats.schemas.officeDocument.x2006.sharedTypes.STTrueFalse;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTBody;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTHdrFtr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTHdrFtrRef;
@@ -51,7 +52,6 @@ import com.microsoft.schemas.vml.CTShape;
 import com.microsoft.schemas.vml.CTShapetype;
 import com.microsoft.schemas.vml.CTTextPath;
 import com.microsoft.schemas.vml.STExt;
-import com.microsoft.schemas.vml.STTrueFalse;
 
 /**
  * A .docx file can have no headers/footers, the same header/footer


### PR DESCRIPTION
POI version 4.1.2 [depends on packages with security vulnerabilities](https://mvnrepository.com/artifact/org.apache.poi/poi/4.1.2), so this PR upgrades to the latest version.

All the tests pass, but I'm not 100% certain that there are no errors. For example, in this line (no 613)

```
field.setDirty(STOnOff1.ON);
```

it turns out `setDirty` takes `java.lang.Object` so it's only at runtime that you discover that passing in the old types no longer works.

Unfortunately, short of creating lots more test cases to cover everything I don't really see how to make sure everything is OK. And I'm not sure how to make test cases to cover everything.