### PR TITLE
Fix issue #98 by explicitly passing class to LogManager.getLogger

### DIFF
--- a/src/main/java/org/wordinator/xml2docx/generator/DocxGenerator.java
+++ b/src/main/java/org/wordinator/xml2docx/generator/DocxGenerator.java
@@ -375,7 +375,7 @@ public class DocxGenerator {
 
   }
 
-  public static final Logger log = LogManager.getLogger();
+  public static final Logger log = LogManager.getLogger(DocxGenerator.class);
 
   private File outFile;
   private int dotsPerInch = 72; /* DPI */


### PR DESCRIPTION
This was much easier to solve than anticipated.