### PR TITLE
Support setting border properties on nested tables

### DIFF
--- a/src/main/doctypes/simplewpml/simplewpml-base.rng
+++ b/src/main/doctypes/simplewpml/simplewpml-base.rng
@@ -1330,11 +1330,23 @@
           </choice>
         </attribute>
       </optional>
-      
-      <ref name="style-atts"/>    
+      <optional>
+        <attribute name="align">
+          <a:documentation>
+            <p>Specifies the alignment of the table with respect to the text margins, but not the text inside the table. The default is implementation-dependent, but 'start' is typical.</p>
+          </a:documentation>
+          <choice>
+            <value type="string">start</value>
+            <value type="string">center</value>
+            <value type="string">end</value>
+          </choice>
+        </attribute>
+      </optional>
+
+      <ref name="style-atts"/>
     </element>
   </define>
-  
+
   <define name="cols">
     <element name="cols" ns="urn:ns:wordinator:simplewpml">
       <a:documentation>

--- a/src/main/java/org/wordinator/xml2docx/generator/DocxGenerator.java
+++ b/src/main/java/org/wordinator/xml2docx/generator/DocxGenerator.java
@@ -45,6 +45,7 @@ import org.apache.poi.xwpf.usermodel.BodyElementType;
 import org.apache.poi.xwpf.usermodel.BreakType;
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.ParagraphAlignment;
+import org.apache.poi.xwpf.usermodel.TableRowAlign;
 import org.apache.poi.xwpf.usermodel.UnderlinePatterns;
 import org.apache.poi.xwpf.usermodel.XWPFAbstractFootnoteEndnote;
 import org.apache.poi.xwpf.usermodel.XWPFAbstractNum;
@@ -2707,8 +2708,7 @@ private void handleCustomProperties(XWPFDocument doc, XmlObject xml) {
 
     setTableIndents(table, cursor);
     setTableLayout(table, cursor);
-
-
+    setTableAlign(table, cursor);
 
     String styleName = cursor.getAttributeText(DocxConstants.QNAME_STYLE_ATT);
     String styleId = cursor.getAttributeText(DocxConstants.QNAME_STYLEID_ATT);
@@ -2854,6 +2854,26 @@ private void handleCustomProperties(XWPFDocument doc, XmlObject xml) {
 
   }
 
+  private void setTableAlign(XWPFTable table, XmlCursor cursor) throws DocxGenerationException {
+    String align = cursor.getAttributeText(DocxConstants.QNAME_ALIGN_ATT);
+    if (align == null) {
+      return;
+    }
+
+    TableRowAlign alignObj;
+    if (align.equals("start")) {
+      alignObj = TableRowAlign.LEFT;
+    } else if (align.equals("center")) {
+      alignObj = TableRowAlign.CENTER;
+    } else if (align.equals("end")) {
+      alignObj = TableRowAlign.RIGHT;
+    } else {
+      throw new DocxGenerationException("Unknown value for table align: '" +
+                                        align + "'");
+    }
+
+    table.setTableAlignment(alignObj);
+  }
 
   /**
    * Sets the w:tblLayout to fixed or auto

--- a/src/main/java/org/wordinator/xml2docx/generator/DocxGenerator.java
+++ b/src/main/java/org/wordinator/xml2docx/generator/DocxGenerator.java
@@ -3398,15 +3398,13 @@ private void handleCustomProperties(XWPFDocument doc, XmlObject xml) {
 	
 	              // record how many tables were in the cell previously
 	              int preTables = cell.getCTTc().getTblList().size();
-	  
+
 	              CTTbl ctTbl = cell.getCTTc().addNewTbl();
 	              ctTbl = cell.getCTTc().addNewTbl();
-	              CTTblPr tblPr = ctTbl.addNewTblPr();
-	              tblPr.addNewTblW();
-	  
+
 	              XWPFTable nestedTable = new XWPFTable(ctTbl, cell);
 	              makeTable(nestedTable, cursor.getObject());
-	  
+
 	              // for some reason this inserts two tables, where the
 	              // first one is empty. we need to remove that one.
 	              // luckily, the number of tables we used to have equals

--- a/src/test/java/org/wordinator/xml2docx/TestDocxGenerator.java
+++ b/src/test/java/org/wordinator/xml2docx/TestDocxGenerator.java
@@ -17,6 +17,7 @@ import org.apache.poi.xwpf.model.XWPFHeaderFooterPolicy;
 import org.apache.poi.xwpf.usermodel.BodyElementType;
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.IRunElement;
+import org.apache.poi.xwpf.usermodel.TableRowAlign;
 import org.apache.poi.xwpf.usermodel.XWPFAbstractNum;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFFooter;
@@ -860,6 +861,29 @@ public class TestDocxGenerator extends TestCase {
     assertEquals(STPageOrientation.Enum.forString("portrait"), pageSz.getOrient());
     assertEquals(BigInteger.valueOf(11906), pageSz.getW());
     assertEquals(BigInteger.valueOf(16838), pageSz.getH());
+  }
+
+  public void testTableAlign() throws Exception {
+    XWPFDocument doc = convert("simplewp/simplewpml-table-align.swpx", "out/table-align.docx");
+    List<IBodyElement> contents = doc.getBodyElements();
+    assertEquals(2, contents.size());
+
+    // first table
+    Iterator<IBodyElement> it = contents.iterator();
+    IBodyElement elem = it.next();
+    assertEquals(BodyElementType.TABLE, elem.getElementType());
+
+    XWPFTable t = (XWPFTable) elem;
+    TableRowAlign align = t.getTableAlignment();
+    assertEquals(TableRowAlign.LEFT, align);
+
+    // second table
+    elem = it.next();
+    assertEquals(BodyElementType.TABLE, elem.getElementType());
+
+    t = (XWPFTable) elem;
+    align = t.getTableAlignment();
+    assertEquals(TableRowAlign.CENTER, align);
   }
 
   // ===== INTERNAL UTILITIES

--- a/src/test/java/org/wordinator/xml2docx/TestDocxGenerator.java
+++ b/src/test/java/org/wordinator/xml2docx/TestDocxGenerator.java
@@ -886,6 +886,31 @@ public class TestDocxGenerator extends TestCase {
     assertEquals(TableRowAlign.CENTER, align);
   }
 
+  public void testNestedTableBorders() throws Exception {
+    XWPFDocument doc = convert("simplewp/simplewpml-issue-157-nested-tables.swpx", "out/nested-tables.docx");
+    List<IBodyElement> contents = doc.getBodyElements();
+    assertEquals(1, contents.size());
+
+    // outer table
+    Iterator<IBodyElement> it = contents.iterator();
+    IBodyElement elem = it.next();
+    assertEquals(BodyElementType.TABLE, elem.getElementType());
+
+    XWPFTable t = (XWPFTable) elem;
+
+    // inner table
+    XWPFTableCell cell = t.getRows().get(0).getTableCells().get(0);
+    elem = cell.getBodyElements().get(0);
+    assertEquals(BodyElementType.TABLE, elem.getElementType());
+    t = (XWPFTable) elem;
+
+    // check the border properties
+    assertEquals(XWPFTable.XWPFBorderType.NONE, t.getLeftBorderType());
+    assertEquals(XWPFTable.XWPFBorderType.NONE, t.getRightBorderType());
+    assertEquals(XWPFTable.XWPFBorderType.NONE, t.getTopBorderType());
+    assertEquals(XWPFTable.XWPFBorderType.NONE, t.getBottomBorderType());
+  }
+
   // ===== INTERNAL UTILITIES
 
   private XWPFDocument convert(String infile, String outfile) throws Exception {

--- a/src/test/resources/simplewp/simplewpml-issue-157-nested-tables.swpx
+++ b/src/test/resources/simplewp/simplewpml-issue-157-nested-tables.swpx
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wp:document xmlns:wp="urn:ns:wordinator:simplewpml">
+  <wp:body>
+    <wp:table align="center" layout="auto" frame="none" colsep="0" rowsep="0" width="100%">
+      <wp:tbody>
+        <wp:tr>
+          <wp:td valign="top" align="left">
+            <wp:table align="center" layout="auto" frame="none" colsep="0" rowsep="0" width="100%">
+              <wp:cols>
+                <wp:col colwidth="50%"/>
+                <wp:col colwidth="50%"/>
+              </wp:cols>
+              <wp:tbody>
+                <wp:tr>
+                  <wp:td valign="top" align="left">
+                    <wp:p>
+                      <wp:run>Q [m</wp:run>
+                      <wp:run vertical-alignment="superscript">3</wp:run>
+                      <wp:run>/h]</wp:run>
+                    </wp:p>
+                  </wp:td>
+                  <wp:td valign="top" align="left">
+                    <wp:p>
+                      <wp:run>water flow</wp:run>
+                    </wp:p>
+                  </wp:td>
+                </wp:tr>
+                <wp:tr>
+                  <wp:td valign="top" align="left">
+                    <wp:p>
+                      <wp:run>k</wp:run>
+                      <wp:run vertical-alignment="subscript">v</wp:run>
+                      <wp:run> [m</wp:run>
+                      <wp:run vertical-alignment="superscript">3</wp:run>
+                      <wp:run>/h]</wp:run>
+                    </wp:p>
+                  </wp:td>
+                  <wp:td valign="top" align="left">
+                    <wp:p>
+                      <wp:run>flow coefficient of the valve     </wp:run>
+                    </wp:p>
+                  </wp:td>
+                </wp:tr>
+                <wp:tr>
+                  <wp:td valign="top" align="left">
+                    <wp:p>
+                      <wp:run>Δp</wp:run>
+                      <wp:run vertical-alignment="subscript">v</wp:run>
+                      <wp:run> [bar]</wp:run>
+                    </wp:p>
+                  </wp:td>
+                  <wp:td valign="top" align="left">
+                    <wp:p>
+                      <wp:run>differential pressure across the valve</wp:run>
+                    </wp:p>
+                  </wp:td>
+                </wp:tr>
+                <wp:tr>
+                  <wp:td valign="top" align="left">
+                    <wp:p>
+                      <wp:run>Δp</wp:run>
+                      <wp:run vertical-alignment="subscript">1bar</wp:run>
+                      <wp:run> [bar]</wp:run>
+                    </wp:p>
+                  </wp:td>
+                  <wp:td valign="top" align="left">
+                    <wp:p>
+                      <wp:run>1 bar differential pressure</wp:run>
+                    </wp:p>
+                  </wp:td>
+                </wp:tr>
+              </wp:tbody>
+            </wp:table>
+          </wp:td>
+          <wp:td valign="top" align="left"/>
+        </wp:tr>
+      </wp:tbody>
+    </wp:table>
+  </wp:body>
+</wp:document>

--- a/src/test/resources/simplewp/simplewpml-table-align.swpx
+++ b/src/test/resources/simplewp/simplewpml-table-align.swpx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wp:document xmlns:wp="urn:ns:wordinator:simplewpml">
+  <wp:body>
+    <!-- left-aligned table -->
+    <wp:table layout="auto" align="start">
+      <wp:tbody>
+        <wp:tr>
+          <wp:td>
+            <wp:p>
+              <wp:run>Left-aligned</wp:run>
+            </wp:p>
+          </wp:td>
+          <wp:td>
+            <wp:p>
+              <wp:run>table</wp:run>
+            </wp:p>
+          </wp:td>
+        </wp:tr>
+      </wp:tbody>
+    </wp:table>
+
+    <!-- centered table -->
+    <wp:table layout="auto" align="center">
+      <wp:tbody>
+        <wp:tr>
+          <wp:td>
+            <wp:p>
+              <wp:run>Centered</wp:run>
+            </wp:p>
+          </wp:td>
+          <wp:td>
+            <wp:p>
+              <wp:run>table</wp:run>
+            </wp:p>
+          </wp:td>
+        </wp:tr>
+      </wp:tbody>
+    </wp:table>
+  </wp:body>
+</wp:document>


### PR DESCRIPTION
This fixes issue 157.

The problem was that when we creat nested tables we have to use a very convoluted API to make the innermost table, and we used code that created a table properties object. Somehow doing this causes Apache POI to create two table properties objects (which shouldn't be possible), leading to malformed WordML output with two table properties elements in it. Removing the creation of this dummy table properties object solves the problem.

Note that this PR includes the table align PR, so best to review and merge that one first.